### PR TITLE
Implementing lighting calibration page

### DIFF
--- a/react_frontend/src/__tests__/patient/LightingCalibration.test.js
+++ b/react_frontend/src/__tests__/patient/LightingCalibration.test.js
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+import LightingCalibration from "../../pages/patient/LightingCalibration";
+
+jest.useFakeTimers();
+
+describe("LightingCalibration", () => {
+  test("renders the correct text content", () => {
+    render(
+      <Router>
+        <LightingCalibration />
+      </Router>
+    );
+
+    expect(screen.getByText(/Lighting Calibration/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/1. Ensure your face is visible./i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/2. Ensure good lighting conditions./i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/3. Ensure there is no strong light behind your back./i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/4. Ensure there are no light reflections on glasses./i)
+    ).toBeInTheDocument();
+  });
+
+  test("redirects to gaze calibration page when Start Calibration button is clicked", () => {
+    render(
+      <Router>
+        <LightingCalibration />
+      </Router>
+    );
+
+    const startButton = screen.getByRole("button", {
+      name: /Start Gaze Calibration/i,
+    });
+    fireEvent.click(startButton);
+
+    expect(window.location.pathname).toBe("/gaze-calibration");
+  });
+
+//   test("displays error message when lighting is poor", async () => {});
+//   test("displays success message when lighting is good", async () => {});
+//   test("shows camera error message if camera access fails", async () => {});
+});

--- a/react_frontend/src/pages/patient/LightingCalibration.css
+++ b/react_frontend/src/pages/patient/LightingCalibration.css
@@ -94,3 +94,8 @@
 .start-button:hover {
   background-color: #8496aa;
 }
+
+.start-button:disabled {
+  background-color: #D3D3D3;
+  cursor: not-allowed;
+}

--- a/react_frontend/src/pages/patient/LightingCalibration.css
+++ b/react_frontend/src/pages/patient/LightingCalibration.css
@@ -1,11 +1,25 @@
-.home-container {
-  padding: 20px;
+.lighting-container {
+  width: 100%;
+  height: 100vh;
+  padding: 20px 0;
   text-align: center;
+  justify-content: center;
   background-color: #FFF3E3;
 }
 
+.title-container-lighting-calibration {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  justify-content: left;
+}
+
+.title-image-small {
+  width: 175px;
+}
+
 .camera-position-rectangle {
-  width: 50%;
+  width: 40%;
   height: auto;
   margin: 20px auto;
   position: relative;
@@ -22,7 +36,8 @@
 }
 
 .instructions-container {
-  width: 50%;
+  background-color: #FFF3E3;
+  width: 40%;
   margin: 0 auto;
 }
 
@@ -36,7 +51,7 @@
 .instruction-list {
   list-style-type: none;
   padding: 0;
-  font-size: 18px;
+  font-size: 20px;
   margin-top: 40px;
   margin-bottom: 40px;
   text-align: left;
@@ -48,6 +63,14 @@
 
 .error-message {
   color: red;
+  font-size: 20px;
+  font-weight: bold;
+  text-align: center;
+  margin-top: 10px;
+}
+
+.success-message {
+  color: #9EC180;
   font-size: 20px;
   font-weight: bold;
   text-align: center;

--- a/react_frontend/src/pages/patient/LightingCalibration.js
+++ b/react_frontend/src/pages/patient/LightingCalibration.js
@@ -1,7 +1,7 @@
-import React, { useRef, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Container } from '@mui/material';
-import './LightingCalibration.css';
+import React, { useRef, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import titleImage from "../../assets/title.svg";
+import "./LightingCalibration.css";
 
 const LightingCalibration = () => {
   const videoRef = useRef(null);
@@ -15,12 +15,16 @@ const LightingCalibration = () => {
     // Request access to the camera
     const startCamera = async () => {
       try {
-        const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: true,
+        });
         if (videoRef.current) {
           videoRef.current.srcObject = stream; // Attach the stream to the video element
         }
       } catch (error) {
-        setCameraError('Unable to access camera. Please check your permissions.');
+        setCameraError(
+          "Unable to access camera. Please check your permissions."
+        );
       }
     };
 
@@ -40,10 +44,21 @@ const LightingCalibration = () => {
     // Check lighting every second (or as needed)
     const checkLighting = () => {
       if (videoRef.current && canvasRef.current) {
-        const context = canvasRef.current.getContext('2d');
-        context.drawImage(videoRef.current, 0, 0, canvasRef.current.width, canvasRef.current.height);
+        const context = canvasRef.current.getContext("2d");
+        context.drawImage(
+          videoRef.current,
+          0,
+          0,
+          canvasRef.current.width,
+          canvasRef.current.height
+        );
 
-        const imageData = context.getImageData(0, 0, canvasRef.current.width, canvasRef.current.height);
+        const imageData = context.getImageData(
+          0,
+          0,
+          canvasRef.current.width,
+          canvasRef.current.height
+        );
         const pixels = imageData.data;
 
         let totalBrightness = 0;
@@ -75,11 +90,11 @@ const LightingCalibration = () => {
   }, []);
 
   const handleStartCalibration = () => {
-    navigate('/gaze-calibration');
+    navigate("/gaze-calibration");
   };
 
   return (
-    <Container className="home-container">
+    <div className="lighting-container">
       {/* Video Feed or Error Message */}
       <div className="camera-position-rectangle">
         {cameraError ? (
@@ -96,9 +111,10 @@ const LightingCalibration = () => {
       </div>
 
       <div className="instructions-container">
-        <h3 className="title">
-          How to Set Up Eye Tracking
-        </h3>
+        <div className="title-container-lighting-calibration">
+          <img src={titleImage} alt="Title" className="title-image-small" />
+        </div>
+        <h3 className="title">Lighting Calibration</h3>
 
         <ul className="instruction-list">
           <li>1. Ensure your face is visible.</li>
@@ -108,10 +124,10 @@ const LightingCalibration = () => {
         </ul>
       </div>
 
-      {!isLightingGood && (
-        <p className='error-message'>
-          Please sit in a well lit room!
-        </p>
+      {!isLightingGood ? (
+        <p className="error-message">PLEASE SIT IN A WELL LIT ROOM.</p>
+      ) : (
+        <p className="success-message">GOOD LIGHTING CONDITIONS.</p>
       )}
 
       <button
@@ -122,8 +138,13 @@ const LightingCalibration = () => {
         Start Gaze Calibration
       </button>
 
-      <canvas ref={canvasRef} width="640" height="480" style={{ display: 'none' }}></canvas>
-    </Container>
+      <canvas
+        ref={canvasRef}
+        width="640"
+        height="480"
+        style={{ display: "none" }}
+      ></canvas>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Ticket
[CGNFY-11](https://asma71612.atlassian.net/browse/CGNFY-11)

## Includes
- Implementing the lighting calibration page
- Bhecks for good or bad lighting based on luminosity formula
  - Button to advance to gaze calibration is locked until user is in good lighting
- The arbitrary threshold of "good" vs "bad" will be changed in the future based on more research of what is sufficient for the gaze tracking

## Note
- I chose to exclude the step 1, step 2, step 3 thing outlined in the Figma because it makes the screen cluttered for no reason and the user probably does not look at that text anyways - in short, it provides no value

## Testing
- Tested locally
- Unit tests (not complete but good enough for now)

Good lighting condition:
![image](https://github.com/user-attachments/assets/f95d3455-397e-4e66-b85f-03baaf3d2999)

Bad lighting condition:
![image](https://github.com/user-attachments/assets/1a038634-69aa-4508-b54e-77cd10cf30d4)