### PR TITLE
CGNFY-47: Daily reporting see more

### DIFF
--- a/react_frontend/src/App.js
+++ b/react_frontend/src/App.js
@@ -26,6 +26,7 @@ const App = () => {
     <Router>
       <Routes>
         <Route path="/" element={<HomeLandingPage />} />
+        <Route path="/home" element={<HomeLandingPage />} />
         <Route path="/patient-login" element={<PatientLoginPage />} />
         <Route path="/patient-home-page" element={<PatientHomePage />} />
         <Route path="/patient-report-page" element={<PatientReportPage />} />

--- a/react_frontend/src/components/DailyReportComponent.css
+++ b/react_frontend/src/components/DailyReportComponent.css
@@ -73,7 +73,7 @@
   font-weight: bold;
 }
 
-.game-box {
+.game-box-neutral {
   padding-left: 0px;
   margin-bottom: 60px;
 }

--- a/react_frontend/src/components/DailyReportComponent.css
+++ b/react_frontend/src/components/DailyReportComponent.css
@@ -140,3 +140,17 @@
 .percentage-change {
   font-weight: bold;
 }
+
+.see-more-container {
+  text-align: center;
+  margin-top: -10px;
+  margin-bottom: 35px;
+}
+
+.see-more-link {
+  color: #2F3B66;
+  font-size: 20px;
+  font-weight: bold;
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/react_frontend/src/components/DailyReportComponent.js
+++ b/react_frontend/src/components/DailyReportComponent.js
@@ -55,8 +55,7 @@ const formatFieldValue = (metric, value) => {
   return value;
 };
 
-const DailyReportComponent = ({ patientId }) => {
-  // Use the passed-in patientId or fall back to localStorage
+const DailyReportComponent = ({ patientId, onSeeMore }) => {
   const effectivePatientId = patientId || localStorage.getItem("userId");
 
   const [patientData, setPatientData] = useState(null);
@@ -227,6 +226,17 @@ const DailyReportComponent = ({ patientId }) => {
               </div>
             );
           })}
+        </div>
+      )}
+
+      {selectedDate && onSeeMore && (
+        <div className="see-more-container">
+          <span
+            className="see-more-link"
+            onClick={() => onSeeMore(selectedDate)}
+          >
+            See More
+          </span>
         </div>
       )}
     </div>

--- a/react_frontend/src/components/DailyReportComponent.js
+++ b/react_frontend/src/components/DailyReportComponent.js
@@ -171,7 +171,7 @@ const DailyReportComponent = ({ patientId, onSeeMore }) => {
           {Object.keys(gameResults).map((gameKey) => {
             const gameName = gameNames[gameKey] || gameKey;
             return (
-              <div key={gameKey} className="game-box">
+              <div key={gameKey} className="game-box-neutral">
                 <h3 className="game-title">{gameName}</h3>
                 <div className="game-metrics">
                   {Object.entries(gameResults[gameKey]).map(

--- a/react_frontend/src/components/DailyReportsSeeMoreComponent.css
+++ b/react_frontend/src/components/DailyReportsSeeMoreComponent.css
@@ -63,6 +63,10 @@
   margin-top: 20px;
 }
 
+.game-section p {
+  margin-left: 10px;
+}
+
 .game-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -79,6 +83,10 @@
   border-radius: 40px;
   padding: 10px;
   height: auto;
+}
+
+.game-box p {
+  margin-left: 20px;
 }
 
 .game-box-vault {

--- a/react_frontend/src/components/DailyReportsSeeMoreComponent.css
+++ b/react_frontend/src/components/DailyReportsSeeMoreComponent.css
@@ -23,12 +23,10 @@
 }
 
 .back-button {
-  padding: 8px 16px;
-  background-color: #e7eaf8;
-  border: 2px solid #516a80;
-  border-radius: 20px;
   cursor: pointer;
-  font-size: 16px;
+  font-size: 20px;
+  margin-left: 3px;
+  color: #2f3b66;
 }
 
 .buttons-container {
@@ -143,4 +141,8 @@
 .table-row span {
   flex: 1;
   text-align: center;
+}
+
+.no-metrics-available p {
+  color: red;
 }

--- a/react_frontend/src/components/DailyReportsSeeMoreComponent.css
+++ b/react_frontend/src/components/DailyReportsSeeMoreComponent.css
@@ -39,43 +39,93 @@
 
 .report-button {
   flex: 1;
-  margin: 10px 10px;
+  margin: 10px;
   padding: 17px 20px;
-  background-color: #516A80;
-  color: #FFFFFF;
+  background-color: #516a80;
+  color: #ffffff;
   border-radius: 20px;
   font-size: 16px;
   cursor: pointer;
   transition: background-color 0.2s;
+  border: none;
 }
 
 .report-button:hover {
-  background-color: #2F3B66;
+  background-color: #2f3b66;
+}
+
+.report-button.active {
+  background-color: #2f3b66;
+  cursor: default;
 }
 
 .scene-detective-section {
   margin-top: 20px;
 }
 
-.scene-detective-section h2 {
-  font-size: 30px;
-  margin-bottom: 20px;
-}
-
 .scene-detective-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-gap: 25px;
+  grid-column-gap: 45px;
 }
 
 .scene-box {
   margin-top: 20px;
   border: 3px solid #2f3b66;
   background-color: #e7eaf8;
-  border-radius: 30px;
-  height: 250px;
+  border-radius: 40px;
+  padding: 10px;
+  height: auto;
 }
 
-.scene-box.span-2 {
-  align-items: center;
+.scene-box h3 {
+  text-align: center;
+  font-size: 24px;
+  margin-bottom: 20px;
+  margin-top: 20px;
+}
+
+.fields {
+  margin-bottom: 20px;
+}
+
+.fields p {
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-bottom: 0px;
+  margin-top: 10px;
+}
+
+.table-container {
+  background-color: #c6cadd;
+  padding: 10px;
+  border-radius: 15px;
+  margin-top: 20px;
+  margin-bottom: 20px;
+  margin-right: 20px;
+  margin-left: 20px;
+}
+
+.table-header {
+  display: flex;
+  font-weight: bold;
+  border-bottom: 1px solid #2f3b66;
+  padding-bottom: 5px;
+  margin-bottom: 5px;
+}
+
+.table-header span {
+  flex: 1;
+  text-align: center;
+}
+
+.table-row {
+  display: flex;
+  padding: 4px 0;
+}
+
+.table-row span {
+  flex: 1;
+  text-align: center;
 }

--- a/react_frontend/src/components/DailyReportsSeeMoreComponent.css
+++ b/react_frontend/src/components/DailyReportsSeeMoreComponent.css
@@ -41,6 +41,8 @@
   flex: 1;
   margin: 10px;
   padding: 17px 20px;
+  margin-right: 20px;
+  margin-bottom: -15px;
   background-color: #516a80;
   color: #ffffff;
   border-radius: 20px;
@@ -59,31 +61,44 @@
   cursor: default;
 }
 
-.scene-detective-section {
+.game-section {
   margin-top: 20px;
 }
 
-.scene-detective-grid {
+.game-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-gap: 25px;
   grid-column-gap: 45px;
+  margin-right: 20px;
 }
 
-.scene-box {
+.game-box {
   margin-top: 20px;
-  border: 3px solid #2f3b66;
+  margin-bottom: 0px;
+  border: 4px solid #516a80;
   background-color: #e7eaf8;
   border-radius: 40px;
   padding: 10px;
   height: auto;
 }
 
-.scene-box h3 {
+.game-box-vault {
+  margin-top: 50px;
+  border: 4px solid #516a80;
+  background-color: #e7eaf8;
+  border-radius: 40px;
+  padding: 10px;
+  height: auto;
+  margin-right: 20px;
+}
+
+.game-box h3,
+.game-box-vault h3 {
   text-align: center;
   font-size: 24px;
   margin-bottom: 20px;
-  margin-top: 20px;
+  margin-top: 15px;
 }
 
 .fields {

--- a/react_frontend/src/components/DailyReportsSeeMoreComponent.css
+++ b/react_frontend/src/components/DailyReportsSeeMoreComponent.css
@@ -1,0 +1,81 @@
+.daily-reports-see-more-container {
+  margin-top: 100px;
+  margin-left: 80px;
+  margin-right: 80px;
+  width: -webkit-fill-available;
+}
+
+.header-section {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.daily-reports-see-more-container h1 {
+  font-size: 50px;
+  font-weight: bold;
+  margin-bottom: 20px;
+}
+
+.back-button-container {
+  text-align: left;
+  margin-bottom: 10px;
+}
+
+.back-button {
+  padding: 8px 16px;
+  background-color: #e7eaf8;
+  border: 2px solid #516a80;
+  border-radius: 20px;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+.buttons-container {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 30px;
+}
+
+.report-button {
+  flex: 1;
+  margin: 10px 10px;
+  padding: 17px 20px;
+  background-color: #516A80;
+  color: #FFFFFF;
+  border-radius: 20px;
+  font-size: 16px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.report-button:hover {
+  background-color: #2F3B66;
+}
+
+.scene-detective-section {
+  margin-top: 20px;
+}
+
+.scene-detective-section h2 {
+  font-size: 30px;
+  margin-bottom: 20px;
+}
+
+.scene-detective-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-gap: 25px;
+}
+
+.scene-box {
+  margin-top: 20px;
+  border: 3px solid #2f3b66;
+  background-color: #e7eaf8;
+  border-radius: 30px;
+  height: 250px;
+}
+
+.scene-box.span-2 {
+  align-items: center;
+}

--- a/react_frontend/src/components/DailyReportsSeeMoreComponent.js
+++ b/react_frontend/src/components/DailyReportsSeeMoreComponent.js
@@ -22,6 +22,7 @@ const DailyReportsSeeMoreComponent = ({ selectedDate, onBack }) => {
   const [sceneData, setSceneData] = useState(null);
   const [processQuestData, setProcessQuestData] = useState(null);
   const [memoryVaultData, setMemoryVaultData] = useState(null);
+  const [naturesGazeData, setNaturesGazeData] = useState(null);
   const [patientData, setPatientData] = useState(null);
 
   const effectivePatientId = localStorage.getItem("userId");
@@ -41,6 +42,7 @@ const DailyReportsSeeMoreComponent = ({ selectedDate, onBack }) => {
     fetchPatientData();
   }, [effectivePatientId]);
 
+  // Fetch Scene Detective Data
   useEffect(() => {
     const fetchSceneData = async () => {
       if (!selectedDate || !effectivePatientId) return;
@@ -91,6 +93,7 @@ const DailyReportsSeeMoreComponent = ({ selectedDate, onBack }) => {
     }
   }, [selectedGame, selectedDate, effectivePatientId]);
 
+  // Fetch Process Quest Data
   useEffect(() => {
     const fetchProcessQuestData = async () => {
       if (!selectedDate || !effectivePatientId) return;
@@ -141,6 +144,7 @@ const DailyReportsSeeMoreComponent = ({ selectedDate, onBack }) => {
     }
   }, [selectedGame, selectedDate, effectivePatientId]);
 
+  // Fetch Memory Vault Data
   useEffect(() => {
     const fetchMemoryVaultData = async () => {
       if (!selectedDate || !effectivePatientId) return;
@@ -164,6 +168,347 @@ const DailyReportsSeeMoreComponent = ({ selectedDate, onBack }) => {
       fetchMemoryVaultData();
     }
   }, [selectedGame, selectedDate, effectivePatientId]);
+
+  // Fetch Natures Gaze Data
+  useEffect(() => {
+    const fetchNaturesGazeData = async () => {
+      if (!selectedDate || !effectivePatientId) return;
+      let data = {};
+
+      try {
+        const fixationAccuracyRef = doc(
+          db,
+          `users/${effectivePatientId}/dailyReportsSeeMore/${selectedDate}/naturesGaze/fixationAccuracy`
+        );
+        const fixationAccuracySnap = await getDoc(fixationAccuracyRef);
+        if (fixationAccuracySnap.exists()) {
+          let fixationAccuracyData = fixationAccuracySnap.data();
+          const landingAccuracyRef = collection(
+            db,
+            `users/${effectivePatientId}/dailyReportsSeeMore/${selectedDate}/naturesGaze/fixationAccuracy/landingAccuracy`
+          );
+          const landingAccuracySnapshot = await getDocs(landingAccuracyRef);
+          let landingAccuracy = {};
+          landingAccuracySnapshot.forEach((docSnap) => {
+            landingAccuracy[docSnap.id] = docSnap.data();
+          });
+          fixationAccuracyData.landingAccuracy = landingAccuracy;
+          data.fixationAccuracy = fixationAccuracyData;
+        }
+      } catch (error) {
+        console.error(
+          "Error fetching naturesGaze fixationAccuracy data",
+          error
+        );
+      }
+
+      try {
+        const fixationDurationRef = doc(
+          db,
+          `users/${effectivePatientId}/dailyReportsSeeMore/${selectedDate}/naturesGaze/fixationDuration`
+        );
+        const fixationDurationSnap = await getDoc(fixationDurationRef);
+        if (fixationDurationSnap.exists()) {
+          let fixationDurationData = fixationDurationSnap.data();
+          const durationsRef = collection(
+            db,
+            `users/${effectivePatientId}/dailyReportsSeeMore/${selectedDate}/naturesGaze/fixationDuration/durations`
+          );
+          const durationsSnapshot = await getDocs(durationsRef);
+          let durations = {};
+          durationsSnapshot.forEach((docSnap) => {
+            durations[docSnap.id] = docSnap.data();
+          });
+          fixationDurationData.durations = durations;
+          data.fixationDuration = fixationDurationData;
+        }
+      } catch (error) {
+        console.error(
+          "Error fetching naturesGaze fixationDuration data",
+          error
+        );
+      }
+
+      try {
+        const fixationErrorRef = doc(
+          db,
+          `users/${effectivePatientId}/dailyReportsSeeMore/${selectedDate}/naturesGaze/fixationError`
+        );
+        const fixationErrorSnap = await getDoc(fixationErrorRef);
+        if (fixationErrorSnap.exists()) {
+          let fixationErrorData = fixationErrorSnap.data();
+          const errorsRef = collection(
+            db,
+            `users/${effectivePatientId}/dailyReportsSeeMore/${selectedDate}/naturesGaze/fixationError/errors`
+          );
+          const errorsSnapshot = await getDocs(errorsRef);
+          let errors = {};
+          errorsSnapshot.forEach((docSnap) => {
+            errors[docSnap.id] = docSnap.data();
+          });
+          fixationErrorData.errors = errors;
+          data.fixationError = fixationErrorData;
+        }
+      } catch (error) {
+        console.error("Error fetching naturesGaze fixationError data", error);
+      }
+
+      try {
+        const reactionTimeRef = doc(
+          db,
+          `users/${effectivePatientId}/dailyReportsSeeMore/${selectedDate}/naturesGaze/reactionTime`
+        );
+        const reactionTimeSnap = await getDoc(reactionTimeRef);
+        if (reactionTimeSnap.exists()) {
+          data.reactionTime = reactionTimeSnap.data();
+        }
+      } catch (error) {
+        console.error("Error fetching naturesGaze reactionTime data", error);
+      }
+
+      try {
+        const saccadeDirectionAccuracyRef = doc(
+          db,
+          `users/${effectivePatientId}/dailyReportsSeeMore/${selectedDate}/naturesGaze/saccadeDirectionAccuracy`
+        );
+        const saccadeDirectionAccuracySnap = await getDoc(
+          saccadeDirectionAccuracyRef
+        );
+        if (saccadeDirectionAccuracySnap.exists()) {
+          let saccadeDirectionAccuracyData =
+            saccadeDirectionAccuracySnap.data();
+          const accuracyRef = collection(
+            db,
+            `users/${effectivePatientId}/dailyReportsSeeMore/${selectedDate}/naturesGaze/saccadeDirectionAccuracy/accuracy`
+          );
+          const accuracySnapshot = await getDocs(accuracyRef);
+          let accuracy = {};
+          accuracySnapshot.forEach((docSnap) => {
+            accuracy[docSnap.id] = docSnap.data();
+          });
+          saccadeDirectionAccuracyData.accuracy = accuracy;
+          data.saccadeDirectionAccuracy = saccadeDirectionAccuracyData;
+        }
+      } catch (error) {
+        console.error(
+          "Error fetching naturesGaze saccadeDirectionAccuracy data",
+          error
+        );
+      }
+
+      try {
+        const saccadeDirectionErrorRef = doc(
+          db,
+          `users/${effectivePatientId}/dailyReportsSeeMore/${selectedDate}/naturesGaze/saccadeDirectionError`
+        );
+        const saccadeDirectionErrorSnap = await getDoc(
+          saccadeDirectionErrorRef
+        );
+        if (saccadeDirectionErrorSnap.exists()) {
+          let saccadeDirectionErrorData = saccadeDirectionErrorSnap.data();
+          const errorsRef = collection(
+            db,
+            `users/${effectivePatientId}/dailyReportsSeeMore/${selectedDate}/naturesGaze/saccadeDirectionError/errors`
+          );
+          const errorsSnapshot = await getDocs(errorsRef);
+          let errors = {};
+          errorsSnapshot.forEach((docSnap) => {
+            errors[docSnap.id] = docSnap.data();
+          });
+          saccadeDirectionErrorData.errors = errors;
+          data.saccadeDirectionError = saccadeDirectionErrorData;
+        }
+      } catch (error) {
+        console.error(
+          "Error fetching naturesGaze saccadeDirectionError data",
+          error
+        );
+      }
+
+      try {
+        const saccadeDurationRef = doc(
+          db,
+          `users/${effectivePatientId}/dailyReportsSeeMore/${selectedDate}/naturesGaze/saccadeDuration`
+        );
+        const saccadeDurationSnap = await getDoc(saccadeDurationRef);
+        if (saccadeDurationSnap.exists()) {
+          let saccadeDurationData = saccadeDurationSnap.data();
+          const durationsRef = collection(
+            db,
+            `users/${effectivePatientId}/dailyReportsSeeMore/${selectedDate}/naturesGaze/saccadeDuration/durations`
+          );
+          const durationsSnapshot = await getDocs(durationsRef);
+          let durations = {};
+          durationsSnapshot.forEach((docSnap) => {
+            durations[docSnap.id] = docSnap.data();
+          });
+          saccadeDurationData.durations = durations;
+          data.saccadeDuration = saccadeDurationData;
+        }
+      } catch (error) {
+        console.error("Error fetching naturesGaze saccadeDuration data", error);
+      }
+
+      try {
+        const saccadeOmissionPercentagesRef = doc(
+          db,
+          `users/${effectivePatientId}/dailyReportsSeeMore/${selectedDate}/naturesGaze/saccadeOmissionPercentages`
+        );
+        const saccadeOmissionPercentagesSnap = await getDoc(
+          saccadeOmissionPercentagesRef
+        );
+        if (saccadeOmissionPercentagesSnap.exists()) {
+          data.saccadeOmissionPercentages =
+            saccadeOmissionPercentagesSnap.data();
+        }
+      } catch (error) {
+        console.error(
+          "Error fetching naturesGaze saccadeOmissionPercentages data",
+          error
+        );
+      }
+
+      setNaturesGazeData(data);
+    };
+
+    if (selectedGame === "naturesGaze") {
+      fetchNaturesGazeData();
+    }
+  }, [selectedGame, selectedDate, effectivePatientId]);
+
+  const renderFixationAccuracyTable = (landingAccuracy) => {
+    return (
+      <div className="table-container">
+        <div className="table-header">
+          <span>Task</span>
+          <span>Landing Accuracy</span>
+          <span>Confidence Interval</span>
+        </div>
+        {Object.entries(landingAccuracy).map(([task, data]) => (
+          <div key={task} className="table-row">
+            <span>{task}</span>
+            <span>{data.LandingAccuracy}</span>
+            <span>{data.ConfidenceInterval}</span>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  const renderFixationDurationTable = (durations) => {
+    return (
+      <div className="table-container">
+        <div className="table-header">
+          <span>Task</span>
+          <span>Duration</span>
+        </div>
+        {Object.entries(durations).map(([task, data]) => (
+          <div key={task} className="table-row">
+            <span>{task}</span>
+            <span>{data.Duration}</span>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  const renderFixationErrorTable = (errors) => {
+    return (
+      <div className="table-container">
+        <div className="table-header">
+          <span>Task</span>
+          <span>Error Count</span>
+          <span>Percent Error</span>
+        </div>
+        {Object.entries(errors).map(([task, data]) => (
+          <div key={task} className="table-row">
+            <span>{task}</span>
+            <span>{data.ErrorCount}</span>
+            <span>{data.PercentError}</span>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  const renderSaccadeDirectionAccuracyTable = (accuracy) => {
+    return (
+      <div className="table-container">
+        <div className="table-header">
+          <span>Task</span>
+          <span>Percent Accuracy</span>
+        </div>
+        {Object.entries(accuracy).map(([task, data]) => (
+          <div key={task} className="table-row">
+            <span>{task}</span>
+            <span>{data.PercentAccuracy}</span>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  const renderSaccadeDirectionErrorTable = (errors) => {
+    return (
+      <div className="table-container">
+        <div className="table-header">
+          <span>Task</span>
+          <span>Error Count</span>
+          <span>Percent Error</span>
+        </div>
+        {Object.entries(errors).map(([task, data]) => (
+          <div key={task} className="table-row">
+            <span>{task}</span>
+            <span>{data.ErrorCount}</span>
+            <span>{data.PercentError}</span>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  const renderSaccadeDurationTable = (durations) => {
+    return (
+      <div className="table-container">
+        <div className="table-header">
+          <span>Task</span>
+          <span>Duration</span>
+        </div>
+        {Object.entries(durations).map(([task, data]) => (
+          <div key={task} className="table-row">
+            <span>{task}</span>
+            <span>{data.Duration}</span>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  const renderReactionTime = (reactionTime) => {
+    return (
+      <div className="fields">
+        <p>
+          <strong>Gap Task:</strong> {reactionTime.GapTask}
+        </p>
+        <p>
+          <strong>Overlap Task:</strong> {reactionTime.OverlapTask}
+        </p>
+      </div>
+    );
+  };
+
+  const renderSaccadeOmissionPercentages = (data) => {
+    return (
+      <div className="fields">
+        <p>
+          <strong>Gap Task:</strong> {data.GapTask}
+        </p>
+        <p>
+          <strong>Overlap Task:</strong> {data.OverlapTask}
+        </p>
+      </div>
+    );
+  };
 
   const renderLexicalFeatures = (fields) => {
     return (
@@ -308,7 +653,7 @@ const DailyReportsSeeMoreComponent = ({ selectedDate, onBack }) => {
           Scene Detective
         </button>
       </div>
-      {/* Game Section View */}
+      {/* Game Section Views */}
       {selectedGame === "sceneDetective" && (
         <div className="game-section">
           {sceneData === null ? (
@@ -452,7 +797,7 @@ const DailyReportsSeeMoreComponent = ({ selectedDate, onBack }) => {
           ) : Object.keys(memoryVaultData).length === 0 ? (
             <p>No metrics available for Memory Vault on this date.</p>
           ) : (
-            <div className="game-box">
+            <div className="game-box-vault">
               <h3>Recall Speed and Accuracy</h3>
               {renderMemoryVaultTable(
                 memoryVaultData["recallSpeedAndAccuracy"]
@@ -461,7 +806,176 @@ const DailyReportsSeeMoreComponent = ({ selectedDate, onBack }) => {
           )}
         </div>
       )}
-      <div style={{ height: "100px" }}></div> {/* Spacer to allow scrolling */}
+      {selectedGame === "naturesGaze" && (
+        <div className="game-section">
+          {naturesGazeData === null ? (
+            <p>Loading Natures Gaze data...</p>
+          ) : Object.keys(naturesGazeData).length === 0 ? (
+            <p>No metrics available for Natures Gaze on this date.</p>
+          ) : (
+            <div className="game-grid">
+              <div className="game-box">
+                <h3>Fixation Accuracy</h3>
+                {naturesGazeData.fixationAccuracy &&
+                naturesGazeData.fixationAccuracy.landingAccuracy ? (
+                  renderFixationAccuracyTable(
+                    naturesGazeData.fixationAccuracy.landingAccuracy
+                  )
+                ) : (
+                  <p>No landing accuracy data.</p>
+                )}
+              </div>
+              <div className="game-box">
+                <h3>Fixation Duration</h3>
+                {naturesGazeData.fixationDuration ? (
+                  <>
+                    {naturesGazeData.fixationDuration
+                      .AverageFixationDuration && (
+                      <p>
+                        <strong>Average Fixation Duration:</strong>{" "}
+                        {
+                          naturesGazeData.fixationDuration
+                            .AverageFixationDuration
+                        }
+                      </p>
+                    )}
+                    {naturesGazeData.fixationDuration.durations ? (
+                      renderFixationDurationTable(
+                        naturesGazeData.fixationDuration.durations
+                      )
+                    ) : (
+                      <p>No duration data.</p>
+                    )}
+                  </>
+                ) : (
+                  <p>No fixation duration data.</p>
+                )}
+              </div>
+              <div className="game-box">
+                <h3>Fixation Error</h3>
+                {naturesGazeData.fixationError ? (
+                  <>
+                    {naturesGazeData.fixationError
+                      .AverageFixationErrorPercentage && (
+                      <p>
+                        <strong>Average Fixation Error Percentage:</strong>{" "}
+                        {
+                          naturesGazeData.fixationError
+                            .AverageFixationErrorPercentage
+                        }
+                      </p>
+                    )}
+                    {naturesGazeData.fixationError.errors ? (
+                      renderFixationErrorTable(
+                        naturesGazeData.fixationError.errors
+                      )
+                    ) : (
+                      <p>No error data.</p>
+                    )}
+                  </>
+                ) : (
+                  <p>No fixation error data.</p>
+                )}
+              </div>
+              <div className="game-box">
+                <h3>Saccade Direction Accuracy</h3>
+                {naturesGazeData.saccadeDirectionAccuracy ? (
+                  <>
+                    {naturesGazeData.saccadeDirectionAccuracy
+                      .AverageSaccadeDirectionPercentage && (
+                      <p>
+                        <strong>Average Saccade Direction Accuracy:</strong>{" "}
+                        {
+                          naturesGazeData.saccadeDirectionAccuracy
+                            .AverageSaccadeDirectionPercentage
+                        }
+                      </p>
+                    )}
+                    {naturesGazeData.saccadeDirectionAccuracy.accuracy ? (
+                      renderSaccadeDirectionAccuracyTable(
+                        naturesGazeData.saccadeDirectionAccuracy.accuracy
+                      )
+                    ) : (
+                      <p>No accuracy data.</p>
+                    )}
+                  </>
+                ) : (
+                  <p>No saccade direction accuracy data.</p>
+                )}
+              </div>
+              <div className="game-box">
+                <h3>Saccade Direction Error</h3>
+                {naturesGazeData.saccadeDirectionError ? (
+                  <>
+                    {naturesGazeData.saccadeDirectionError
+                      .AverageSaccadeErrorPercentage && (
+                      <p>
+                        <strong>
+                          Average Saccade Direction Error Percentage:
+                        </strong>{" "}
+                        {
+                          naturesGazeData.saccadeDirectionError
+                            .AverageSaccadeErrorPercentage
+                        }
+                      </p>
+                    )}
+                    {naturesGazeData.saccadeDirectionError.errors ? (
+                      renderSaccadeDirectionErrorTable(
+                        naturesGazeData.saccadeDirectionError.errors
+                      )
+                    ) : (
+                      <p>No error data.</p>
+                    )}
+                  </>
+                ) : (
+                  <p>No saccade direction error data.</p>
+                )}
+              </div>
+              <div className="game-box">
+                <h3>Saccade Duration</h3>
+                {naturesGazeData.saccadeDuration ? (
+                  <>
+                    {naturesGazeData.saccadeDuration.AverageSaccadeDuration && (
+                      <p>
+                        <strong>Average Saccade Duration:</strong>{" "}
+                        {naturesGazeData.saccadeDuration.AverageSaccadeDuration}
+                      </p>
+                    )}
+                    {naturesGazeData.saccadeDuration.durations ? (
+                      renderSaccadeDurationTable(
+                        naturesGazeData.saccadeDuration.durations
+                      )
+                    ) : (
+                      <p>No duration data.</p>
+                    )}
+                  </>
+                ) : (
+                  <p>No saccade duration data.</p>
+                )}
+              </div>
+              <div className="game-box">
+                <h3>Saccade Omission Percentages</h3>
+                {naturesGazeData.saccadeOmissionPercentages ? (
+                  renderSaccadeOmissionPercentages(
+                    naturesGazeData.saccadeOmissionPercentages
+                  )
+                ) : (
+                  <p>No omission percentages data.</p>
+                )}
+              </div>
+              <div className="game-box">
+                <h3>Reaction Time</h3>
+                {naturesGazeData.reactionTime ? (
+                  renderReactionTime(naturesGazeData.reactionTime)
+                ) : (
+                  <p>No reaction time data.</p>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+      <div style={{ height: "100px" }}></div> {/* Spacer for scrolling */}
     </div>
   );
 };

--- a/react_frontend/src/components/DailyReportsSeeMoreComponent.js
+++ b/react_frontend/src/components/DailyReportsSeeMoreComponent.js
@@ -17,6 +17,25 @@ const metricTitles = {
   temporalCharacteristics: "Temporal Characteristics",
 };
 
+const lexicalFeaturesOrder = [
+  "ClosedClass",
+  "Filler",
+  "Noun",
+  "OpenClass",
+  "Verb",
+];
+
+const semanticFeaturesOrder = [
+  "SemanticUnits",
+  "SemanticIdeaDensity",
+  "SemanticEfficiency",
+  "LexicalFrequencyOfNouns",
+];
+
+const fluencyMetricsOrder = ["WordsPerMin", "RevisionRatio"];
+
+const structuralFeaturesOrder = ["NumOfSentences", "MeanLengthOfOccurrence"];
+
 const DailyReportsSeeMoreComponent = ({ selectedDate, onBack }) => {
   const [selectedGame, setSelectedGame] = useState("");
   const [sceneData, setSceneData] = useState(null);
@@ -511,17 +530,105 @@ const DailyReportsSeeMoreComponent = ({ selectedDate, onBack }) => {
   };
 
   const renderLexicalFeatures = (fields) => {
+    const sortedFields = Object.keys(fields)
+      .sort(
+        (a, b) =>
+          lexicalFeaturesOrder.indexOf(a) - lexicalFeaturesOrder.indexOf(b)
+      )
+      .reduce((obj, key) => {
+        obj[key] = fields[key];
+        return obj;
+      }, {});
+
     return (
       <div className="table-container">
         <div className="table-header">
           <span>Word Types</span>
           <span>Count</span>
         </div>
-        {Object.entries(fields).map(([key, value]) => (
+        {Object.entries(sortedFields).map(([key, value]) => (
           <div key={key} className="table-row">
             <span>{formatMetricName(key)}</span>
             <span>{value}</span>
           </div>
+        ))}
+      </div>
+    );
+  };
+
+  const renderSemanticFeatures = (fields) => {
+    const sortedFields = Object.keys(fields)
+      .sort(
+        (a, b) =>
+          semanticFeaturesOrder.indexOf(a) - semanticFeaturesOrder.indexOf(b)
+      )
+      .reduce((obj, key) => {
+        obj[key] = fields[key];
+        return obj;
+      }, {});
+
+    return (
+      <div className="fields">
+        {Object.entries(sortedFields).map(([key, value]) => (
+          <p key={key}>
+            <strong>{formatMetricName(key)}:</strong> {value}
+          </p>
+        ))}
+      </div>
+    );
+  };
+
+  const renderStutters = (stutters) => {
+    return (
+      <div className="table-container">
+        <div className="table-header">
+          <span>Stutter #</span>
+          <span>Time</span>
+        </div>
+        {stutters.map((stutter, index) => (
+          <div key={stutter.id} className="table-row">
+            <span>{index + 1}</span>
+            <span>{stutter.Time}</span>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  const renderFluencyMetrics = (fields) => {
+    const sortedFields = fluencyMetricsOrder.reduce((obj, key) => {
+      if (fields[key] !== undefined) {
+        obj[key] = fields[key];
+      }
+      return obj;
+    }, {});
+
+    return (
+      <div className="fields">
+        {Object.entries(sortedFields).map(([key, value]) => (
+          <p key={key}>
+            <strong>{formatMetricName(key)}:</strong> {value}
+          </p>
+        ))}
+        {fields.stutters && renderStutters(fields.stutters)}
+      </div>
+    );
+  };
+
+  const renderStructuralFeatures = (fields) => {
+    const sortedFields = structuralFeaturesOrder.reduce((obj, key) => {
+      if (fields[key] !== undefined) {
+        obj[key] = fields[key];
+      }
+      return obj;
+    }, {});
+
+    return (
+      <div className="fields">
+        {Object.entries(sortedFields).map(([key, value]) => (
+          <p key={key}>
+            <strong>{formatMetricName(key)}:</strong> {value}
+          </p>
         ))}
       </div>
     );
@@ -550,23 +657,6 @@ const DailyReportsSeeMoreComponent = ({ selectedDate, onBack }) => {
             </div>
           );
         })}
-      </div>
-    );
-  };
-
-  const renderStutters = (stutters) => {
-    return (
-      <div className="table-container">
-        <div className="table-header">
-          <span>Stutter #</span>
-          <span>Time</span>
-        </div>
-        {stutters.map((stutter, index) => (
-          <div key={stutter.id} className="table-row">
-            <span>{index + 1}</span>
-            <span>{stutter.Time}</span>
-          </div>
-        ))}
       </div>
     );
   };
@@ -674,22 +764,12 @@ const DailyReportsSeeMoreComponent = ({ selectedDate, onBack }) => {
                   <div className="fields">
                     {metric === "lexicalFeatures" ? (
                       renderLexicalFeatures(sceneData[metric])
+                    ) : metric === "semanticFeatures" ? (
+                      renderSemanticFeatures(sceneData[metric])
                     ) : metric === "fluencyMetrics" ? (
-                      <>
-                        {Object.entries(sceneData[metric]).map(
-                          ([field, value]) => {
-                            if (field === "stutters") return null;
-                            return (
-                              <p key={field}>
-                                <strong>{formatMetricName(field)}:</strong>{" "}
-                                {value}
-                              </p>
-                            );
-                          }
-                        )}
-                        {sceneData[metric].stutters &&
-                          renderStutters(sceneData[metric].stutters)}
-                      </>
+                      renderFluencyMetrics(sceneData[metric])
+                    ) : metric === "structuralFeatures" ? (
+                      renderStructuralFeatures(sceneData[metric])
                     ) : metric === "temporalCharacteristics" ? (
                       <>
                         {Object.entries(sceneData[metric]).map(
@@ -742,22 +822,12 @@ const DailyReportsSeeMoreComponent = ({ selectedDate, onBack }) => {
                   <div className="fields">
                     {metric === "lexicalFeatures" ? (
                       renderLexicalFeatures(processQuestData[metric])
+                    ) : metric === "semanticFeatures" ? (
+                      renderSemanticFeatures(processQuestData[metric])
                     ) : metric === "fluencyMetrics" ? (
-                      <>
-                        {Object.entries(processQuestData[metric]).map(
-                          ([field, value]) => {
-                            if (field === "stutters") return null;
-                            return (
-                              <p key={field}>
-                                <strong>{formatMetricName(field)}:</strong>{" "}
-                                {value}
-                              </p>
-                            );
-                          }
-                        )}
-                        {processQuestData[metric].stutters &&
-                          renderStutters(processQuestData[metric].stutters)}
-                      </>
+                      renderFluencyMetrics(processQuestData[metric])
+                    ) : metric === "structuralFeatures" ? (
+                      renderStructuralFeatures(processQuestData[metric])
                     ) : metric === "temporalCharacteristics" ? (
                       <>
                         {Object.entries(processQuestData[metric]).map(

--- a/react_frontend/src/components/DailyReportsSeeMoreComponent.js
+++ b/react_frontend/src/components/DailyReportsSeeMoreComponent.js
@@ -1,9 +1,15 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import { collection, getDocs } from "firebase/firestore";
+import { db } from "../firebaseConfig";
 import "./DailyReportsSeeMoreComponent.css";
 
 const formatSelectedDate = (dateStr) => {
   const [month, day, year] = dateStr.split("-");
-  const dateObj = new Date(parseInt(year, 10), parseInt(month, 10) - 1, parseInt(day, 10));
+  const dateObj = new Date(
+    parseInt(year, 10),
+    parseInt(month, 10) - 1,
+    parseInt(day, 10)
+  );
   return dateObj.toLocaleDateString("en-US", {
     month: "long",
     day: "numeric",
@@ -11,9 +17,135 @@ const formatSelectedDate = (dateStr) => {
   });
 };
 
+const formatMetricName = (name) => {
+  return name.replace(/([a-z])([A-Z])/g, "$1 $2").replace(/_/g, " ");
+};
+
+const metricTitles = {
+  fluencyMetrics: "Fluency Metrics",
+  lexicalFeatures: "Lexical Features",
+  structuralFeatures: "Structural Features",
+  semanticFeatures: "Semantic Features",
+  temporalCharacteristics: "Temporal Characteristics",
+};
+
 const DailyReportsSeeMoreComponent = ({ selectedDate, onBack }) => {
   const formattedDate = selectedDate ? formatSelectedDate(selectedDate) : "";
   const [selectedGame, setSelectedGame] = useState("");
+  const [sceneData, setSceneData] = useState(null);
+
+  const effectivePatientId = localStorage.getItem("userId");
+
+  useEffect(() => {
+    const fetchSceneData = async () => {
+      if (!selectedDate || !effectivePatientId) return;
+      try {
+        const sceneRef = collection(
+          db,
+          `users/${effectivePatientId}/dailyReportsSeeMore/${selectedDate}/sceneDetective`
+        );
+        const snapshot = await getDocs(sceneRef);
+        let data = {};
+        snapshot.forEach((docSnap) => {
+          data[docSnap.id] = docSnap.data();
+        });
+
+        if (data["temporalCharacteristics"]) {
+          const pausesRef = collection(
+            db,
+            `users/${effectivePatientId}/dailyReportsSeeMore/${selectedDate}/sceneDetective/temporalCharacteristics/Pauses`
+          );
+          const pausesSnapshot = await getDocs(pausesRef);
+          let pauses = [];
+          pausesSnapshot.forEach((docSnap) => {
+            pauses.push({ id: docSnap.id, ...docSnap.data() });
+          });
+          data["temporalCharacteristics"].pauses = pauses;
+        }
+
+        if (data["fluencyMetrics"]) {
+          const stuttersRef = collection(
+            db,
+            `users/${effectivePatientId}/dailyReportsSeeMore/${selectedDate}/sceneDetective/fluencyMetrics/Stutters`
+          );
+          const stuttersSnapshot = await getDocs(stuttersRef);
+          let stutters = [];
+          stuttersSnapshot.forEach((docSnap) => {
+            stutters.push({ id: docSnap.id, ...docSnap.data() });
+          });
+          data["fluencyMetrics"].stutters = stutters;
+        }
+        setSceneData(data);
+      } catch (error) {
+        console.error("Error fetching scene detective data:", error);
+      }
+    };
+
+    if (selectedGame === "sceneDetective") {
+      fetchSceneData();
+    }
+  }, [selectedGame, selectedDate, effectivePatientId]);
+
+  const renderLexicalFeatures = (fields) => {
+    return (
+      <div className="table-container">
+        <div className="table-header">
+          <span>Word Types</span>
+          <span>Count</span>
+        </div>
+        {Object.entries(fields).map(([key, value]) => (
+          <div key={key} className="table-row">
+            <span>{formatMetricName(key)}</span>
+            <span>{value}</span>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  const renderPauses = (pauses) => {
+    return (
+      <div className="table-container">
+        <div className="table-header">
+          <span>Pause #</span>
+          <span>Start Time</span>
+          <span>End Time</span>
+          <span>Duration</span>
+        </div>
+        {pauses.map((pause, index) => {
+          const start = parseFloat(pause.StartTime);
+          const end = parseFloat(pause.EndTime);
+          const duration =
+            !isNaN(start) && !isNaN(end) ? (end - start).toFixed(2) : "N/A";
+          return (
+            <div key={pause.id} className="table-row">
+              <span>{index + 1}</span>
+              <span>{pause.StartTime}</span>
+              <span>{pause.EndTime}</span>
+              <span>{duration}</span>
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const renderStutters = (stutters) => {
+    return (
+      <div className="table-container">
+        <div className="table-header">
+          <span>Stutter #</span>
+          <span>Time</span>
+        </div>
+        {stutters.map((stutter, index) => (
+          <div key={stutter.id} className="table-row">
+            <span>{index + 1}</span>
+            <span>{stutter.Time}</span>
+          </div>
+        ))}
+      </div>
+    );
+  };
 
   return (
     <div className="daily-reports-see-more-container">
@@ -25,37 +157,111 @@ const DailyReportsSeeMoreComponent = ({ selectedDate, onBack }) => {
         </div>
       )}
       <div className="header-section">
-        <h1>
-          Daily Reports {formattedDate && `for ${formattedDate}`}
-        </h1>
+        <h1>Daily Reports {formattedDate && `for ${formattedDate}`}</h1>
       </div>
-      {/* Four game buttons */}
+      {/* Game Buttons */}
       <div className="buttons-container">
-        <button className="report-button" onClick={() => setSelectedGame("naturesGaze")}>
+        <button
+          className={`report-button ${
+            selectedGame === "naturesGaze" ? "active" : ""
+          }`}
+          onClick={() => setSelectedGame("naturesGaze")}
+        >
           Natures Gaze I/II
         </button>
-        <button className="report-button" onClick={() => setSelectedGame("memoryVault")}>
+        <button
+          className={`report-button ${
+            selectedGame === "memoryVault" ? "active" : ""
+          }`}
+          onClick={() => setSelectedGame("memoryVault")}
+        >
           Memory Vault
         </button>
-        <button className="report-button" onClick={() => setSelectedGame("processQuest")}>
+        <button
+          className={`report-button ${
+            selectedGame === "processQuest" ? "active" : ""
+          }`}
+          onClick={() => setSelectedGame("processQuest")}
+        >
           Process Quest
         </button>
-        <button className="report-button" onClick={() => setSelectedGame("sceneDetective")}>
+        <button
+          className={`report-button ${
+            selectedGame === "sceneDetective" ? "active" : ""
+          }`}
+          onClick={() => setSelectedGame("sceneDetective")}
+        >
           Scene Detective
         </button>
       </div>
-
+      {/* Scene Detective View */}
       {selectedGame === "sceneDetective" && (
         <div className="scene-detective-section">
-          <div className="scene-detective-grid">
-            <div className="scene-box"></div>
-            <div className="scene-box"></div>
-            <div className="scene-box"></div>
-            <div className="scene-box"></div>
-            <div className="scene-box span-2"></div>
-          </div>
+          {sceneData ? (
+            <div className="scene-detective-grid">
+              {[
+                "fluencyMetrics",
+                "lexicalFeatures",
+                "temporalCharacteristics",
+                "semanticFeatures",
+                "structuralFeatures",
+              ].map((metric) => (
+                <div key={metric} className="scene-box">
+                  <h3>{metricTitles[metric] || formatMetricName(metric)}</h3>
+                  <div className="fields">
+                    {metric === "lexicalFeatures" ? (
+                      renderLexicalFeatures(sceneData[metric])
+                    ) : metric === "fluencyMetrics" ? (
+                      <>
+                        {Object.entries(sceneData[metric]).map(
+                          ([field, value]) => {
+                            if (field === "stutters") return null;
+                            return (
+                              <p key={field}>
+                                <strong>{formatMetricName(field)}:</strong>{" "}
+                                {value}
+                              </p>
+                            );
+                          }
+                        )}
+                        {sceneData[metric].stutters &&
+                          renderStutters(sceneData[metric].stutters)}
+                      </>
+                    ) : metric === "temporalCharacteristics" ? (
+                      <>
+                        {Object.entries(sceneData[metric]).map(
+                          ([field, value]) => {
+                            if (field === "pauses") return null;
+                            return (
+                              <p key={field}>
+                                <strong>{formatMetricName(field)}:</strong>{" "}
+                                {value}
+                              </p>
+                            );
+                          }
+                        )}
+                        {sceneData[metric].pauses &&
+                          renderPauses(sceneData[metric].pauses)}
+                      </>
+                    ) : (
+                      Object.entries(sceneData[metric]).map(
+                        ([field, value]) => (
+                          <p key={field}>
+                            <strong>{formatMetricName(field)}:</strong> {value}
+                          </p>
+                        )
+                      )
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p>Loading scene detective data...</p>
+          )}
         </div>
       )}
+      <div style={{ height: "100px" }}></div> {/* Spacer to allow scrolling */}
     </div>
   );
 };

--- a/react_frontend/src/components/DailyReportsSeeMoreComponent.js
+++ b/react_frontend/src/components/DailyReportsSeeMoreComponent.js
@@ -1,0 +1,63 @@
+import React, { useState } from "react";
+import "./DailyReportsSeeMoreComponent.css";
+
+const formatSelectedDate = (dateStr) => {
+  const [month, day, year] = dateStr.split("-");
+  const dateObj = new Date(parseInt(year, 10), parseInt(month, 10) - 1, parseInt(day, 10));
+  return dateObj.toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+};
+
+const DailyReportsSeeMoreComponent = ({ selectedDate, onBack }) => {
+  const formattedDate = selectedDate ? formatSelectedDate(selectedDate) : "";
+  const [selectedGame, setSelectedGame] = useState("");
+
+  return (
+    <div className="daily-reports-see-more-container">
+      {onBack && (
+        <div className="back-button-container">
+          <button className="back-button" onClick={onBack}>
+            Back
+          </button>
+        </div>
+      )}
+      <div className="header-section">
+        <h1>
+          Daily Reports {formattedDate && `for ${formattedDate}`}
+        </h1>
+      </div>
+      {/* Four game buttons */}
+      <div className="buttons-container">
+        <button className="report-button" onClick={() => setSelectedGame("naturesGaze")}>
+          Natures Gaze I/II
+        </button>
+        <button className="report-button" onClick={() => setSelectedGame("memoryVault")}>
+          Memory Vault
+        </button>
+        <button className="report-button" onClick={() => setSelectedGame("processQuest")}>
+          Process Quest
+        </button>
+        <button className="report-button" onClick={() => setSelectedGame("sceneDetective")}>
+          Scene Detective
+        </button>
+      </div>
+
+      {selectedGame === "sceneDetective" && (
+        <div className="scene-detective-section">
+          <div className="scene-detective-grid">
+            <div className="scene-box"></div>
+            <div className="scene-box"></div>
+            <div className="scene-box"></div>
+            <div className="scene-box"></div>
+            <div className="scene-box span-2"></div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DailyReportsSeeMoreComponent;

--- a/react_frontend/src/components/PatientInfoBoxComponent.css
+++ b/react_frontend/src/components/PatientInfoBoxComponent.css
@@ -14,7 +14,9 @@
   background-color: #e7eaf8;
   color: #2f3b66;
   padding: 20px;
+  padding-bottom: 10px;
   border-radius: 22px;
+  margin-top: 5px;
   margin-bottom: 20px;
 }
 

--- a/react_frontend/src/components/PatientInfoBoxComponent.css
+++ b/react_frontend/src/components/PatientInfoBoxComponent.css
@@ -1,0 +1,23 @@
+.patient-info-box-container {
+  margin-bottom: 20px;
+  margin-right: 20px;
+}
+
+.patient-info-box-container h1 {
+  font-size: 50px;
+  font-weight: bold;
+  margin-bottom: 20px;
+}
+
+.patient-info-box {
+  border: 4px solid #516a80;
+  background-color: #e7eaf8;
+  color: #2f3b66;
+  padding: 20px;
+  border-radius: 22px;
+  margin-bottom: 20px;
+}
+
+.patient-info-box h2 {
+  margin-top: 0;
+}

--- a/react_frontend/src/components/PatientInfoBoxComponent.js
+++ b/react_frontend/src/components/PatientInfoBoxComponent.js
@@ -1,0 +1,65 @@
+import React from "react";
+import "./PatientInfoBoxComponent.css";
+
+const calculateAge = (dob) => {
+  const birthDate = new Date(dob);
+  const today = new Date();
+  let age = today.getFullYear() - birthDate.getFullYear();
+  if (
+    today.getMonth() < birthDate.getMonth() ||
+    (today.getMonth() === birthDate.getMonth() &&
+      today.getDate() < birthDate.getDate())
+  ) {
+    age--;
+  }
+  return age;
+};
+
+const formatSelectedDate = (dateStr) => {
+  const [month, day, year] = dateStr.split("-");
+  const dateObj = new Date(
+    parseInt(year, 10),
+    parseInt(month, 10) - 1,
+    parseInt(day, 10)
+  );
+  return dateObj.toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+};
+
+const PatientInfoBoxComponent = ({
+  selectedDate,
+  patientData,
+  effectivePatientId,
+}) => {
+  return (
+    <div className="patient-info-box-container">
+      <h1>
+        Daily Reports{" "}
+        {selectedDate && `for ${formatSelectedDate(selectedDate)}`}
+      </h1>
+      {patientData && (
+        <div className="patient-info-box">
+          <h2>
+            {patientData.firstName} {patientData.lastName}{" "}
+            {patientData.dob && patientData.sex && (
+              <span>
+                ({calculateAge(patientData.dob)}, {patientData.sex})
+              </span>
+            )}
+          </h2>
+          <p>
+            <strong>User ID:</strong> {effectivePatientId}
+          </p>
+          <p>
+            <strong>Date of Birth:</strong> {patientData.dob}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PatientInfoBoxComponent;

--- a/react_frontend/src/pages/patient/PatientReportPage.js
+++ b/react_frontend/src/pages/patient/PatientReportPage.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import titleImage from "../../assets/title.svg";
 import homeIcon from "../../assets/home-light.svg";
@@ -6,9 +6,22 @@ import reportIcon from "../../assets/reports-dark.svg";
 import supportIcon from "../../assets/support-light.svg";
 import profileIcon from "../../assets/profile-light.svg";
 import DailyReportComponent from "../../components/DailyReportComponent";
+import DailyReportsSeeMoreComponent from "../../components/DailyReportsSeeMoreComponent";
 import "./PatientReportPage.css";
 
 const PatientReportPage = () => {
+  const [view, setView] = useState("daily");
+  const [selectedDate, setSelectedDate] = useState("");
+
+  const handleSeeMore = (date) => {
+    setSelectedDate(date);
+    setView("seeMore");
+  };
+
+  const handleBack = () => {
+    setView("daily");
+  };
+
   return (
     <div className="patient-home-container">
       {/* Left Navigation */}
@@ -35,9 +48,16 @@ const PatientReportPage = () => {
           <span>Log Out</span>
         </Link>
       </div>
-      {/* Right Side: Shared Daily Report Content */}
+
+      {/* Right Side */}
       <div className="right-side">
-        <DailyReportComponent />
+        {view === "daily" && <DailyReportComponent onSeeMore={handleSeeMore} />}
+        {view === "seeMore" && (
+          <DailyReportsSeeMoreComponent
+            selectedDate={selectedDate}
+            onBack={handleBack}
+          />
+        )}
       </div>
     </div>
   );

--- a/react_frontend/src/pages/physicianReporting/DailyReports.js
+++ b/react_frontend/src/pages/physicianReporting/DailyReports.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import titleImage from "../../assets/title.svg";
 import patientsIcon from "../../assets/my-patients-light.svg";
@@ -8,10 +8,22 @@ import dailyReportsIcon from "../../assets/daily-reports-dark.svg";
 import weeklyReportsIcon from "../../assets/weekly-reports.svg";
 import allTimeReportsIcon from "../../assets/all-time-reports.svg";
 import DailyReportComponent from "../../components/DailyReportComponent";
+import DailyReportsSeeMoreComponent from "../../components/DailyReportsSeeMoreComponent";
 import "./DailyReports.css";
 
 const DailyReports = () => {
   const { patientId } = useParams();
+  const [view, setView] = useState("daily");
+  const [selectedDate, setSelectedDate] = useState("");
+
+  const handleSeeMore = (date) => {
+    setSelectedDate(date);
+    setView("seeMore");
+  };
+
+  const handleBack = () => {
+    setView("daily");
+  };
 
   return (
     <div className="daily-reports-container">
@@ -21,11 +33,17 @@ const DailyReports = () => {
           <img src={titleImage} alt="Title" className="title-image" />
         </div>
         <div className="menu">
-          <Link to="/physician-home-page" className="menu-item-daily-reports link">
+          <Link
+            to="/physician-home-page"
+            className="menu-item-daily-reports link"
+          >
             <img src={patientsIcon} alt="My Patients" />
             <span>My Patients</span>
           </Link>
-          <Link to="/daily-reports" className="menu-item-daily-reports link daily">
+          <Link
+            to="/daily-reports"
+            className="menu-item-daily-reports link daily"
+          >
             <img src={dailyReportsIcon} alt="Daily Reports" />
             <span>Daily Reports</span>
           </Link>
@@ -37,19 +55,36 @@ const DailyReports = () => {
             <img src={allTimeReportsIcon} alt="All-Time Trends" />
             <span>All-Time Trends</span>
           </Link>
-          <Link to="/physician-support" className="menu-item-daily-reports link">
+          <Link
+            to="/physician-support"
+            className="menu-item-daily-reports link"
+          >
             <img src={supportIcon} alt="Support" />
             <span>Support</span>
           </Link>
         </div>
-        <Link to="/physician-login" className="menu-item-daily-reports link logout">
+        <Link
+          to="/physician-login"
+          className="menu-item-daily-reports link logout"
+        >
           <img src={profileIcon} alt="Log Out" />
           <span>Log Out</span>
         </Link>
       </div>
       {/* Right Side: Shared Daily Report Content */}
       <div className="right-side-physician">
-        <DailyReportComponent patientId={patientId} />
+        {view === "daily" && (
+          <DailyReportComponent
+            patientId={patientId}
+            onSeeMore={handleSeeMore}
+          />
+        )}
+        {view === "seeMore" && (
+          <DailyReportsSeeMoreComponent
+            selectedDate={selectedDate}
+            onBack={handleBack}
+          />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Ticket
<!-- Link the corresponding ticket. -->
[CGNFY-47](https://asma71612.atlassian.net/jira/software/projects/CGNFY/boards/1?selectedIssue=CGNFY-47)

## Description
<!-- Provide a short summary of the changes made in this pull request. -->
- Added a "See More" button at the end of every daily reports page for any date to lead to a more in depth analysis of various metrics
- Loads each game's data in different boxes when button is clicked for any specific game
- Has placeholder messages for when the game data is loading (sometimes if the wifi connection is slow it takes 1-2 seconds to load - see image below)
- Has the patient info box on each page to keep consistency (also included on the patient's end because right now I'm reusing components but if anyone feel strongly about making it not visible on the patient's end, I can create a follow up ticket for this)

## Notes
I will implement the explanation of some metrics as part of a different PR since this is very large already. I created a ticket for that here: [CGNFY-48](https://asma71612.atlassian.net/jira/software/projects/CGNFY/boards/1?selectedIssue=CGNFY-48)

I also know some of the code could be cleaned up and refactored, I might do that later but for right now just prioritizing getting things done.

Here is a brief overview of the backend structure of each game and how the metrics are stored:
```
memoryVault (collection)
  - recallSpeedAndAccuracy (document)
    - Presented (field)
    - Recalled (field)
    - TimeToRecall (field)

processQuest  (collection) 
  - fluencyMetrics (document)
    - RevisionRatio (field)
    - WordsPerMin (field)
    - Stutters (collection)
      - 1 (document)
        - Time (field)
      - 2 (document)
        - Time (field)
  - lexicalFeatures (document)
    - ClosedClass (field)
    - Filler (field)
    - Noun (field)
    - OpenClass (field)
    - Verb (field)
  - structuralFeatures (document)
    - MeanLengthOfOccurance (field)
    - NumOfSentences (field)
  - semanticFeatures (document) 
    - LexicalFrequencyOfNouns (field) 
    - SemanticEfficiency (field)
    - SemanticIdeaDensity (field)
    - SemanticUnits (field)
  - temporalCharacteristics (document)
    - SpeakingTime (field)
    - Pauses (collection)
      - 1 (document)
        - StartTime (field)
        - EndTime (field)
      - 2 (document)
        - StartTime (field)
        - EndTime (field)

sceneDetective (same as processQuest)

naturesGaze (collection)
  - fixationAccuracy (document)
    - landingAccuracy (collection) 
      - gap (document) 
        - ConfidenceInterval (field) 
        - LandingAccuracy (field) 
      - overlap (document) 
        - ConfidenceInterval (field) 
        - LandingAccuracy (field) 
  - fixationDuration (document)
    - AverageFixationDuration (field)
    - durations (collection)
      - gap (document) 
        - Duration (field) 
      - overlap (document) 
        - Duration (field) 
  - fixationError (document)
    - AverageFixationErrorPercentage (field)
    - errors (collection)
      - gap (document) 
        - ErrorCount (field) 
        - PercentError (field) 
      - overlap (document) 
        - ErrorCount (field) 
        - PercentError (field) 
  - reactionTime (document)
    - GapTask (field)
    - OverlapTask (field)
  - saccadeDirectionAccuracy (document)
    - AverageSaccadeDirectionPercentage (field)
    - accuracy (collection)
      - antiGap (document)
        - PercentAccuracy (field) 
      - proGap (document)
        - PercentAccuracy (field) 
      - antiOverlap (document)
        - PercentAccuracy (field) 
      - proOverlap (document)
        - PercentAccuracy (field) 
  - saccadeDirectionError (document)
    - AverageSaccadeErrorPercentage (field)
    - errors (collection)
      - antiGap (document)
        - ErrorCount (field) 
        - PercentError (field) 
      - proGap (document)
        - ErrorCount (field) 
        - PercentError (field) 
      - antiOverlap (document)
        - ErrorCount (field) 
        - PercentError (field) 
      - proOverlap (document)
        - ErrorCount (field) 
        - PercentError (field) 
  - saccadeDuration (document)
    - AverageSaccadeDuration (field)
    - durations (collection)
      - antiGap (document)
        - Duration (field) 
      - proGap (document)
        - Duration (field) 
      - antiOverlap (document)
        - Duration (field) 
      - proOverlap (document)
        - Duration (field) 
  - saccadeOmissionPercentages (document)
    - GapTask (field)
    - OverlapTask (field)
```

## Testing 
<!-- Talk about how the code was tested and add any screenshots or videos if PR involves UI/UX changes. -->
- Tested locally
- If you want to test this locally, the dummy is located for this user:
```
Name: Asma Ansari
User-ID: test
Date: 01-01-2025
```

See more button:
![image](https://github.com/user-attachments/assets/55c918ca-1bfa-4688-bc39-30cf79c28cf5)

Game data is loading:
![image](https://github.com/user-attachments/assets/ff4fb2f4-5f0c-4cdd-b1e3-b81e05078715)

No game data for that specific date:
![image](https://github.com/user-attachments/assets/9ea8ca0d-3859-4351-a02a-9f4fe0a8358d)

Main page view with buttons not selected:
![image](https://github.com/user-attachments/assets/9f05fb83-be35-4ffb-88b5-c424ae37f4ce)

Nature's Gaze:
![image](https://github.com/user-attachments/assets/7a7c66bf-169a-4c73-b646-5c8f3da6821c)

Memory Vault:
![image](https://github.com/user-attachments/assets/818f3654-78f2-484b-b319-ec1d723a8e81)

Process Quest:
![image](https://github.com/user-attachments/assets/37f0994b-2281-43cd-bdb8-c9403c89355c)

Scene Detective
![image](https://github.com/user-attachments/assets/d6832f9e-58d6-4880-8b82-c05f084c2e49)

## Checklist
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added documentation where necessary.
